### PR TITLE
_pkg_str: add binpkg_format property

### DIFF
--- a/lib/portage/versions.py
+++ b/lib/portage/versions.py
@@ -457,6 +457,23 @@ class _pkg_str(str):
 			self.__dict__['_stable'] = stable
 			return stable
 
+	@property
+	def binpkg_format(self):
+		"""
+		Returns the BINPKG_FORMAT metadata. A return value of None means
+		that the format is unset. If there is no metadata available or the
+		BINPKG_FORMAT key is missing from the metadata, then raise
+		AttributeError.
+
+		@rtype: str or None
+		@return: a non-empty BINPKG_FORMAT string, or None
+		"""
+		try:
+			return self._metadata['BINPKG_FORMAT'] or None
+		except (AttributeError, KeyError):
+			raise AttributeError('binpkg_format')
+
+
 def pkgsplit(mypkg, silent=1, eapi=None):
 	"""
 	@param mypkg: either a pv or cpv


### PR DESCRIPTION
Returns the BINPKG_FORMAT metadata. A return value of None means
that the format is unset. If there is no metadata available or the
BINPKG_FORMAT key is missing from the metadata, then raise
AttributeError.

In bintree.py, update code to use the _pkg_str.binpkg_format
property where appropriate. This eliminates many redundant calls
to the get_binpkg_format function.

In the binarytree.getname method, slightly refactor logic which
should behave the same as before. It should raise an error if the
desired binpkg_format is not clear. The caller should either set
allocate_new to True or else ensure that cpv.binpkg_format is set
to a particular format.

Signed-off-by: Zac Medico <zmedico@gentoo.org>