### PR TITLE
binarytree._read_metadata: return BINPKG_FORMAT

### DIFF
--- a/bin/quickpkg
+++ b/bin/quickpkg
@@ -16,6 +16,7 @@ import portage
 portage._internal_caller = True
 from portage import os
 from portage import xpak, gpkg
+from portage.const import SUPPORTED_GENTOO_BINPKG_FORMATS
 from portage.dbapi.dep_expand import dep_expand
 from portage.dep import Atom, use_reduce
 from portage.exception import (AmbiguousPackageName, InvalidAtom, InvalidData,
@@ -112,7 +113,7 @@ def quickpkg_atom(options, infos, arg, eout):
 			if update_metadata:
 				vardb.aux_update(cpv, update_metadata)
 
-			binpkg_format = settings.get("BINPKG_FORMAT", "xpak")
+			binpkg_format = settings.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0])
 			if binpkg_format == "xpak":
 				xpdata = xpak.xpak(dblnk.dbdir)
 				binpkg_tmpfile = os.path.join(bintree.pkgdir,

--- a/lib/_emerge/BinpkgFetcher.py
+++ b/lib/_emerge/BinpkgFetcher.py
@@ -115,7 +115,7 @@ class _BinpkgFetcherProcess(SpawnProcess):
 		if bintree._remote_has_index:
 			remote_metadata = bintree._remotepkgs[
 				bintree.dbapi._instance_key(pkg.cpv)]
-			binpkg_format = remote_metadata.get("BINPKG_FORMAT", "xpak")
+			binpkg_format = remote_metadata.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0])
 			if binpkg_format not in SUPPORTED_GENTOO_BINPKG_FORMATS:
 				raise InvalidBinaryPackageFormat(binpkg_format)
 			rel_uri = remote_metadata.get("PATH")

--- a/lib/_emerge/EbuildBinpkg.py
+++ b/lib/_emerge/EbuildBinpkg.py
@@ -6,6 +6,7 @@ from _emerge.EbuildPhase import EbuildPhase
 
 import portage
 from portage import os
+from portage.const import SUPPORTED_GENTOO_BINPKG_FORMATS
 from portage.exception import InvalidBinaryPackageFormat
 
 class EbuildBinpkg(CompositeTask):
@@ -19,7 +20,7 @@ class EbuildBinpkg(CompositeTask):
 		pkg = self.pkg
 		root_config = pkg.root_config
 		bintree = root_config.trees["bintree"]
-		binpkg_format = self.settings.get("BINPKG_FORMAT", "xpak")
+		binpkg_format = self.settings.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0])
 		if binpkg_format == "xpak":
 			binpkg_tmpfile = os.path.join(bintree.pkgdir,
 				pkg.cpv + ".tbz2." + str(portage.getpid()))

--- a/lib/_emerge/EbuildPhase.py
+++ b/lib/_emerge/EbuildPhase.py
@@ -28,6 +28,7 @@ from portage.util._async.BuildLogger import BuildLogger
 from portage.util.futures import asyncio
 from portage.util.futures.executor.fork import ForkExecutor
 from portage.exception import InvalidBinaryPackageFormat
+from portage.const import SUPPORTED_GENTOO_BINPKG_FORMATS
 
 try:
 	from portage.xml.metadata import MetaDataXML
@@ -137,7 +138,7 @@ class EbuildPhase(CompositeTask):
 
 		if self.phase == 'package':
 			if 'PORTAGE_BINPKG_TMPFILE' not in self.settings:
-				binpkg_format = self.settings.get("BINPKG_FORMAT", "xpak")
+				binpkg_format = self.settings.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0])
 				if binpkg_format == "xpak":
 					self.settings['BINPKG_FORMAT'] = "xpak"
 					self.settings['PORTAGE_BINPKG_TMPFILE'] = \

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -25,7 +25,9 @@ portage.proxy.lazyimport.lazyimport(globals(),
 from portage.binrepo.config import BinRepoConfigLoader
 from portage.cache.mappings import slot_dict_class
 from portage.const import (BINREPOS_CONF_FILE, CACHE_PATH,
-	SUPPORTED_XPAK_EXTENSIONS, SUPPORTED_GPKG_EXTENSIONS)
+	SUPPORTED_XPAK_EXTENSIONS, SUPPORTED_GPKG_EXTENSIONS,
+	SUPPORTED_GENTOO_BINPKG_FORMATS,
+)
 from portage.dbapi.virtual import fakedbapi
 from portage.dep import Atom, use_reduce, paren_enclose
 from portage.exception import AlarmSignal, InvalidPackageName, \
@@ -477,7 +479,7 @@ class binarytree:
 
 			# Populate the header with appropriate defaults.
 			self._pkgindex_default_header_data = {
-				"BINPKG_FORMAT": self.settings.get("BINPKG_FORMAT", "xpak"),
+				"BINPKG_FORMAT": self.settings.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0]),
 				"CHOST"        : self.settings.get("CHOST", ""),
 				"repository"   : "",
 			}
@@ -1774,7 +1776,7 @@ class binarytree:
 				# The caller can set cpv.binpkg_format in advance if something
 				# other than the default is desired here.
 				if allocate_new:
-					binpkg_format = self.settings.get('BINPKG_FORMAT', 'xpak')
+					binpkg_format = self.settings.get('BINPKG_FORMAT', SUPPORTED_GENTOO_BINPKG_FORMATS[0])
 				else:
 					binpkg_format = None
 
@@ -1826,7 +1828,7 @@ class binarytree:
 		try:
 			binpkg_format = cpv.binpkg_format
 		except AttributeError:
-			binpkg_format = self.settings.get("BINPKG_FORMAT", "xpak")
+			binpkg_format = self.settings.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0])
 
 		if binpkg_format == "xpak":
 			return os.path.join(self.pkgdir, cpv + ".tbz2")
@@ -1850,7 +1852,7 @@ class binarytree:
 		try:
 			binpkg_format = cpv.binpkg_format
 		except AttributeError:
-			binpkg_format = self.settings.get("BINPKG_FORMAT", "xpak")
+			binpkg_format = self.settings.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0])
 
 		if binpkg_format == "xpak":
 			filename_format = "%s-%s.xpak"

--- a/lib/portage/dbapi/bintree.py
+++ b/lib/portage/dbapi/bintree.py
@@ -1311,9 +1311,8 @@ class binarytree:
 				noiselevel=-1)
 			return
 
-		binpkg_format = get_binpkg_format(full_path)
-		metadata = self._read_metadata(full_path, s, binpkg_format=binpkg_format)
-		metadata["BINPKG_FORMAT"] = binpkg_format
+		metadata = self._read_metadata(full_path, s)
+		binpkg_format = metadata["BINPKG_FORMAT"]
 
 		invalid_depend = False
 		try:
@@ -1465,6 +1464,9 @@ class binarytree:
 				else:
 					v = _unicode_decode(v)
 					metadata[k] = " ".join(v.split())
+
+		metadata["BINPKG_FORMAT"] = binpkg_format
+
 		return metadata
 
 	def _inject_file(self, pkgindex, cpv, filename):

--- a/lib/portage/dbapi/vartree.py
+++ b/lib/portage/dbapi/vartree.py
@@ -50,7 +50,8 @@ portage.proxy.lazyimport.lazyimport(globals(),
 )
 
 from portage.const import CACHE_PATH, CONFIG_MEMORY_FILE, \
-	MERGING_IDENTIFIER, PORTAGE_PACKAGE_ATOM, PRIVATE_PATH, VDB_PATH
+	MERGING_IDENTIFIER, PORTAGE_PACKAGE_ATOM, PRIVATE_PATH, VDB_PATH, \
+	SUPPORTED_GENTOO_BINPKG_FORMATS
 from portage.dbapi import dbapi
 from portage.exception import CommandNotFound, \
 	InvalidData, InvalidLocation, InvalidPackageName, \
@@ -1006,7 +1007,7 @@ class vardbapi(dbapi):
 				'y' if include_unmodified_config else 'n'))
 		opts, args = parser.parse_known_args(opts_list)
 
-		binpkg_format = settings.get("BINPKG_FORMAT", "xpak")
+		binpkg_format = settings.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0])
 		if binpkg_format == "xpak":
 			tar_cmd = ('tar', '-x', '--xattrs', '--xattrs-include=*', '-C', dest_dir)
 			pr, pw = os.pipe()
@@ -1994,7 +1995,7 @@ class dblink:
 		contents = self.getcontents()
 		excluded_config_files = []
 		protect = None
-		binpkg_format = settings.get("BINPKG_FORMAT", "xpak")
+		binpkg_format = settings.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0])
 
 		if not include_config:
 			confprot = ConfigProtect(settings['EROOT'],

--- a/lib/portage/gpg.py
+++ b/lib/portage/gpg.py
@@ -7,6 +7,7 @@ import threading
 import time
 
 from portage import os
+from portage.const import SUPPORTED_GENTOO_BINPKG_FORMATS
 from portage.exception import GPGException
 from portage.output import colorize
 from portage.util import shlex_split, varexpand, writemsg, writemsg_stdout
@@ -34,7 +35,7 @@ class GPG:
 		If gpg-keepalive is set, start keepalive thread.
 		"""
 		if (self.GPG_unlock_command
-			and (self.settings.get("BINPKG_FORMAT", "xpak") == "gpkg")):
+			and (self.settings.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0]) == "gpkg")):
 			try:
 				os.environ["GPG_TTY"] = os.ttyname(sys.stdout.fileno())
 			except OSError as e:

--- a/lib/portage/package/ebuild/doebuild.py
+++ b/lib/portage/package/ebuild/doebuild.py
@@ -48,7 +48,8 @@ from portage import bsd_chflags, \
 	unmerge, _encodings, _os_merge, \
 	_shell_quote, _unicode_decode, _unicode_encode
 from portage.const import EBUILD_SH_ENV_FILE, EBUILD_SH_ENV_DIR, \
-	EBUILD_SH_BINARY, INVALID_ENV_FILE, MISC_SH_BINARY, PORTAGE_PYM_PACKAGES
+	EBUILD_SH_BINARY, INVALID_ENV_FILE, MISC_SH_BINARY, PORTAGE_PYM_PACKAGES, \
+	SUPPORTED_GENTOO_BINPKG_FORMATS
 from portage.data import portage_gid, portage_uid, secpass, \
 	uid, userpriv_groups
 from portage.dbapi.porttree import _parse_uri_map
@@ -532,7 +533,7 @@ def doebuild_environment(myebuild, mydo, myroot=None, settings=None,
 				mysettings["KV"] = ""
 			mysettings.backup_changes("KV")
 
-		binpkg_format = mysettings.get("BINPKG_FORMAT", "xpak")
+		binpkg_format = mysettings.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0])
 		if binpkg_format not in portage.const.SUPPORTED_GENTOO_BINPKG_FORMATS:
 			writemsg("!!! BINPKG_FORMAT contains invalid or "
 				"unsupported format: %s" % binpkg_fotmat,

--- a/lib/portage/tests/emerge/test_simple.py
+++ b/lib/portage/tests/emerge/test_simple.py
@@ -306,7 +306,7 @@ call_has_and_best_version() {
 			port=binhost_server.server_port,
 			path=binhost_remote_path)
 
-		binpkg_format = settings.get("BINPKG_FORMAT", "xpak")
+		binpkg_format = settings.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0])
 		self.assertIn(binpkg_format, ("xpak", "gpkg"))
 		if binpkg_format == "xpak":
 			foo_filename = "foo-0.tbz2"

--- a/lib/portage/tests/resolver/ResolverPlayground.py
+++ b/lib/portage/tests/resolver/ResolverPlayground.py
@@ -9,7 +9,9 @@ import portage
 from itertools import permutations
 from portage import os
 from portage import shutil
-from portage.const import (GLOBAL_CONFIG_PATH, USER_CONFIG_PATH)
+from portage.const import (GLOBAL_CONFIG_PATH, USER_CONFIG_PATH,
+	SUPPORTED_GENTOO_BINPKG_FORMATS,
+)
 from portage.process import find_binary
 from portage.dep import Atom, _repo_separator
 from portage.package.ebuild.config import config
@@ -271,7 +273,7 @@ class ResolverPlayground:
 		# a dict.
 		items = getattr(binpkgs, 'items', None)
 		items = items() if items is not None else binpkgs
-		binpkg_format = self.settings.get("BINPKG_FORMAT", "xpak")
+		binpkg_format = self.settings.get("BINPKG_FORMAT", SUPPORTED_GENTOO_BINPKG_FORMATS[0])
 		if binpkg_format == "gpkg":
 			if self.gpg is None:
 				self.gpg = GPG(self.settings)


### PR DESCRIPTION
Always add BINPKG_FORMAT to the metadata dictionary returned
from _read_metadata, and update the inject method to rely
on this.

Signed-off-by: Zac Medico <zmedico@gentoo.org>